### PR TITLE
refactor everything to incorporate camia units

### DIFF
--- a/analysis/passengers_per_day.py
+++ b/analysis/passengers_per_day.py
@@ -1,22 +1,17 @@
 """Analysis to determine the number of passengers per day globally using models defined in `SRC/aviation`."""
 
-# from camia import _engine as engine
 import camia_engine as engine
+from camia_model.units import year
 
 import aviation
+from aviation.units import passenger
 
-days_per_year = 365.25
-passengers_per_year = 5_000_000_000.0
+passengers_per_year = 5_000_000_000.0 * passenger / year  # not a float anymore
 
-
-inputs = {  # dictionary with strings as keys and floats as values
-    "passengers_per_year": passengers_per_year,
-    "days_per_year": days_per_year,
-}
-
+inputs = {"passengers_per_year": passengers_per_year}
 output = "passengers_per_day"
 
 systems_model = engine.SystemsModel(aviation.transforms)  # equal to SystemModel Class
 passengers_per_day = systems_model.evaluate(inputs, output)
 
-print(f"{passengers_per_day:.0f}")  # format string syntax, will output variable_name=value
+print(f"{passengers_per_day=}")  # format string syntax, will output variable_name=value

--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -1,25 +1,25 @@
 """Analysis to determine the required size of the global fleet using transforms defined in `src/aviation`."""
 
 import camia_engine as engine
+from camia_model.units import day, year
 
 import aviation
+from aviation.units import aircraft, journey, passenger
 
-days_per_year = 365.0
-passengers_per_year = 5_000_000_000.0
-seats_per_aircraft = 200.0
-flights_per_aircraft_per_day = 2.0  # make them all floats
+passengers_per_year = 5_000_000_000.0 * passenger / year
+seats_per_aircraft = 200.0 * passenger / aircraft
+flights_per_aircraft_per_day = 3.0 * journey / (aircraft * day)
 
 
-inputs = {  # dictionary with strings as keys and floats as values
+inputs = {
     "passengers_per_year": passengers_per_year,
-    "days_per_year": days_per_year,
     "seats_per_aircraft": seats_per_aircraft,
     "flights_per_aircraft_per_day": flights_per_aircraft_per_day,
 }
 
 output = "required_global_fleet"
 
-systems_model = engine.SystemsModel(aviation.transforms)  # equal to SystemModel Class
+systems_model = engine.SystemsModel(aviation.transforms)
 required_global_fleet = systems_model.evaluate(inputs, output)
 
-print(f"{required_global_fleet:.0f}")  # format string syntax, will output variable_name=value
+print(f"{required_global_fleet=}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,19 @@
 [project]
-name = "aviation" #package identifier
+name = "aviation"                                            #package identifier
 version = "0.1.0"
 description = "A simple model for global Aviation."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = [
-    "camia-engine>=0.4.4",
-    "camia-model>=0.6.4",
-    "mkdocs-bibtex>=4.4.0",
-]
+dependencies = ["camia-engine>=0.4.4", "camia-model>=0.6.4"]
 
 [dependency-groups]
-dev = ["mypy>=1.17.0", "pre-commit>=4.2.0", "pytest>=8.4.1", "ruff>=0.12.3"]
+dev = [
+    "mypy>=1.17.0",
+    "pre-commit>=4.2.0",
+    "pytest>=8.4.1",
+    "pytest-camia>=0.3.3",
+    "ruff>=0.12.3",
+]
 
 docs = [
     "mkdocs-bibtex>=4.4.0",

--- a/src/aviation/_engine.py
+++ b/src/aviation/_engine.py
@@ -1,7 +1,6 @@
 """systems_model = engine.SystemsModel(aviation.transforms).
 
 required_global_fleet = systems_model.evaluate (inputs, output)
-
 """
 
 import collections.abc
@@ -27,7 +26,7 @@ class SystemsModel:
             if transform.name == output:
                 break
         else:
-            # if we cannot find a tranform amtching the output , raise an error
+            # if we cannot find a tranform matching the output , raise an error
             message = f"No transform with name `{output}`."
             raise ValueError(message)
 

--- a/src/aviation/units.py
+++ b/src/aviation/units.py
@@ -1,0 +1,11 @@
+"""Additional units to support accurate unit anontations for transforms."""
+
+__all__ = ("aircraft", "journey", "passenger")
+
+import camia_model as model
+
+aircraft = model.units.Unit.new_named("aircraft", relation=model.units.DIMENSIONLESS)
+
+passenger = model.units.Unit.new_named("passenger", relation=model.units.DIMENSIONLESS)
+
+journey = model.units.Unit.new_named("journey", relation=model.units.DIMENSIONLESS)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,46 +1,42 @@
+import typing
+
 import camia_engine as engine
 import pytest
+import pytest_camia
+from camia_model.units import day, year
 
-import aviation
+from aviation import transforms
+from aviation.units import aircraft, journey, passenger
 
 
 @pytest.fixture
 def systems_model() -> engine.SystemsModel:
-    return engine.SystemsModel(aviation.transforms)
+    return engine.SystemsModel(transforms)
 
 
 @pytest.mark.parametrize(
     ("inputs", "output", "expected"),
     (
-        ({"passengers_per_year": 5_000_000_000.0}, "passengers_per_year", 5_000_000_000.0),
-        ({"required_global_fleet": 25_000.0}, "required_global_fleet", 25_000.0),
         (
-            {"days_per_year": 365.25, "passengers_per_year": 5_000_000_000.0},
+            {"passengers_per_year": 5_000_000_000.0 * passenger / year},
             "passengers_per_day",
-            13_689_254.0,
+            13_689_254.0 * passenger / day,
         ),
         (
             {
-                "passengers_per_day": 13_689_254.0,
-                "days_per_year": 365.25,
-                "seats_per_aircraft": 200.0,
-                "flights_per_aircraft_per_day": 3.0,
+                "passengers_per_year": 5_000_000_000.0 * passenger / year,
+                "seats_per_aircraft": 200.0 * passenger / aircraft,
+                "flights_per_aircraft_per_day": 3.0 * journey / (aircraft * day),
             },
             "required_global_fleet",
-            22_815.0,
-        ),
-        (
-            {
-                "passengers_per_year": 5_000_000_000.0,
-                "days_per_year": 365.25,
-                "seats_per_aircraft": 200.0,
-                "flights_per_aircraft_per_day": 3.0,
-            },
-            "required_global_fleet",
-            22_815.0,
+            22_815.0 * aircraft,
         ),
     ),
 )
-def test_systems_model_evaluate(inputs: dict[str, float], output: str, expected: float) -> None:
-    systems_model = engine.SystemsModel(aviation.transforms)
-    assert systems_model.evaluate(inputs, output) == pytest.approx(expected, abs=1.0)
+def test_transform_evaluation(
+    systems_model: engine.SystemsModel,
+    inputs: dict[str, typing.Any],
+    output: str,
+    expected: typing.Any,  # noqa: ANN401
+) -> None:
+    assert systems_model.evaluate(inputs, output) == pytest_camia.approx(expected, atol=1.0)

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -1,37 +1,38 @@
+import typing
+
 import pytest
+import pytest_camia
+from camia_model.units import Quantity, day, year
 
 from aviation.fleet import passengers_per_day, required_global_fleet
+from aviation.units import aircraft, journey, passenger
 
 
 @pytest.mark.parametrize(
-    ("passengers_per_year", "days_per_year", "expected_passengers_per_day"),
+    ("passengers_per_year", "expected_passengers_per_day"),
     (
-        (365_000_000.0, 365.0, 1_000_000.0),
-        (732_000_000.0, 366, 2_000_000.0),
+        (365_250_000.0 * passenger / year, 1_000_000.0 * passenger / day),
+        (5_000_000_000.0 * passenger / year, 13_689_254.0 * passenger / day),
     ),
 )
 def test_passengers_per_day(
-    passengers_per_year: float, days_per_year: float, expected_passengers_per_day: float
+    passengers_per_year: typing.Annotated[Quantity, passenger / year],
+    expected_passengers_per_day: typing.Annotated[Quantity, passenger / day],
 ) -> None:
-    assert passengers_per_day(passengers_per_year, days_per_year) == expected_passengers_per_day
+    result = passengers_per_day(passengers_per_year)
+    assert result == pytest_camia.approx(expected_passengers_per_day)
 
 
 def test_required_global_fleet() -> None:
-    days_per_year = 365.0
-    passengers_per_year = 5_000_000_000.0
-    seats_per_aircraft = 200.0
-    flights_per_aircraft_per_day = 2.5
+    passengers_per_year = 5_000_000_000.0 * passenger / year
+    seats_per_aircraft = 200.0 * passenger / aircraft
+    flights_per_aircraft_per_day = 3.0 * journey / (aircraft * day)
 
-    expected_required_global_fleet = 25_000.0
+    expected_required_global_fleet = 25_000.0 * aircraft
 
     result = required_global_fleet(
-        passengers_per_day(passengers_per_year, days_per_year),
+        passengers_per_day(passengers_per_year),
         seats_per_aircraft,
         flights_per_aircraft_per_day,
     )
-    assert result == pytest.approx(expected_required_global_fleet, abs=3_000.0)
-
-
-# def test_passengers_per_day_argument_types_correct():
-#    with pytest.raises(TypeError, match = "Argument `passengers_per_year` passed to `passengers_per_day` function must be an instance of class `float`"):
-#        passengers_per_day("365_000_000.0", 365.0)
+    assert result == pytest_camia.approx(expected_required_global_fleet, atol=10_000.0)

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,6 @@ source = { editable = "." }
 dependencies = [
     { name = "camia-engine" },
     { name = "camia-model" },
-    { name = "mkdocs-bibtex" },
 ]
 
 [package.dev-dependencies]
@@ -17,6 +16,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-camia" },
     { name = "ruff" },
 ]
 docs = [
@@ -31,7 +31,6 @@ docs = [
 requires-dist = [
     { name = "camia-engine", specifier = ">=0.4.4" },
     { name = "camia-model", specifier = ">=0.6.4" },
-    { name = "mkdocs-bibtex", specifier = ">=4.4.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -39,6 +38,7 @@ dev = [
     { name = "mypy", specifier = ">=1.17.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-camia", specifier = ">=0.3.3" },
     { name = "ruff", specifier = ">=0.12.3" },
 ]
 docs = [
@@ -702,6 +702,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-camia"
+version = "0.3.3"
+source = { registry = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/simple" }
+dependencies = [
+    { name = "camia-model" },
+    { name = "pytest" },
+]
+sdist = { url = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/files/8d9884482008d0aa1ebfc7de58de2d4c6ecb8403530eafcabded589cfa09c329/pytest_camia-0.3.3.tar.gz", hash = "sha256:8d9884482008d0aa1ebfc7de58de2d4c6ecb8403530eafcabded589cfa09c329" }
+wheels = [
+    { url = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/files/09a40b27a9271ad30bc02df5858402f09e2cdf4e68412d66456c7c9449fb5cc3/pytest_camia-0.3.3-py3-none-any.whl", hash = "sha256:09a40b27a9271ad30bc02df5858402f09e2cdf4e68412d66456c7c9449fb5cc3" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR refactors the repository to use [camia-model's units system](https://github.com/aviation-impact-accelerator/camia-model/tree/main/src/camia_model/units). It adds custom units for aircraft, journey, and passenger to showcase how these can be added and mixed with existing named units implemented in camia-model. It also showcases how to use camia-model's unit conversion (via Quantity.convert_to(...)) to convert a quantity with one unit to another unit with consistent dimensionality.

It also adds the AIA's [pytest-camia](https://github.com/aviation-impact-accelerator/pytest-camia) to the dev dependency group so that it can be used in tests to compare approximate equality for Quantity instances and to run automated units checking tests on all transforms in the src/ directory.